### PR TITLE
Replace CSGMesh with SurfaceTool for grenade trail

### DIFF
--- a/Player/Grenade.tscn
+++ b/Player/Grenade.tscn
@@ -4,10 +4,10 @@
 [ext_resource type="PackedScene" path="res://Player/GrenadeVisuals/grenade/grenade.tscn" id="2_6f7t1"]
 [ext_resource type="AudioStream" uid="uid://csou1m38pk3m4" path="res://Player/Sounds/musket-explosion-6383.wav" id="3_7x8ud"]
 
-[sub_resource type="SphereShape3D" id="SphereShape3D_uuqo3"]
-radius = 3.6
+[sub_resource type="SphereShape3D" id="SphereShape3D_rejks"]
+radius = 3.0
 
-[sub_resource type="SphereShape3D" id="SphereShape3D_mydce"]
+[sub_resource type="SphereShape3D" id="SphereShape3D_8624p"]
 radius = 0.1
 
 [node name="Grenade" type="CharacterBody3D"]
@@ -19,17 +19,17 @@ script = ExtResource("1_ak024")
 [node name="ExplosionArea" type="Area3D" parent="."]
 
 [node name="CollisionShape3d" type="CollisionShape3D" parent="ExplosionArea"]
-shape = SubResource("SphereShape3D_uuqo3")
+shape = SubResource("SphereShape3D_rejks")
 
 [node name="grenade" parent="." instance=ExtResource("2_6f7t1")]
 
 [node name="CollisionShape3d" type="CollisionShape3D" parent="."]
-shape = SubResource("SphereShape3D_mydce")
+shape = SubResource("SphereShape3D_8624p")
 
 [node name="ExplosionSound" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource("3_7x8ud")
 pitch_scale = 2.0
 
 [node name="ExplosionStartTimer" type="Timer" parent="."]
-wait_time = 0.075
+wait_time = 0.35
 one_shot = true

--- a/Player/GrenadeLauncher.gd
+++ b/Player/GrenadeLauncher.gd
@@ -106,23 +106,23 @@ func _draw_throw_path() -> void:
 		var point_current := _throw_velocity * time_current + Vector3.DOWN * gravity * 0.5 * time_current * time_current
 
 		# Our point coordinates are at the center of the path, so we need to calculate vertices
-		var trail_point_left_1 = point_current + offset_left
-		var trail_point_right_1 = point_current + offset_right
-		var trail_point_left_2 = point_previous + offset_left
-		var trail_point_right_2 = point_previous + offset_right
+		var trail_point_left_end = point_current + offset_left
+		var trail_point_right_end = point_current + offset_right
+		var trail_point_left_start = point_previous + offset_left
+		var trail_point_right_start = point_previous + offset_right
 		
 		# UV position goes from 0 to 1, so we normalize the current iteration
 		# to get the progress in the UV texture
-		var uv_progress_1 = time_current * uv_progress_factor
-		var uv_progress_2 = uv_progress_1 - uv_progress_factor
+		var uv_progress_end = time_current * uv_progress_factor
+		var uv_progress_start = uv_progress_end - uv_progress_factor
 		
 		# Left side on the UV texture is at the top of the texture
 		# (Vector2(0,1), or Vector2.DOWN). Right side on the UV texture is at 
 		# the bottom.
-		var uv_value_right_1 = (Vector2.RIGHT * uv_progress_1)
-		var uv_value_right_2 = (Vector2.RIGHT * uv_progress_2)
-		var uv_value_left_1 = Vector2.DOWN + uv_value_right_1
-		var uv_value_left_2 = Vector2.DOWN + uv_value_right_2
+		var uv_value_right_start = (Vector2.RIGHT * uv_progress_end)
+		var uv_value_right_end = (Vector2.RIGHT * uv_progress_start)
+		var uv_value_left_start = Vector2.DOWN + uv_value_right_start
+		var uv_value_left_end = Vector2.DOWN + uv_value_right_end
 		
 		point_previous = point_current
 
@@ -130,20 +130,20 @@ func _draw_throw_path() -> void:
 		# clockwise orientation to determine the face normal)
 
 		# Draw first triangle
-		st.set_uv(uv_value_left_1)
-		st.add_vertex(trail_point_left_1)
-		st.set_uv(uv_value_left_2)
-		st.add_vertex(trail_point_left_2)
-		st.set_uv(uv_value_right_1)
-		st.add_vertex(trail_point_right_1)
+		st.set_uv(uv_value_right_start)
+		st.add_vertex(trail_point_right_end)
+		st.set_uv(uv_value_left_end)
+		st.add_vertex(trail_point_left_start)
+		st.set_uv(uv_value_left_start)
+		st.add_vertex(trail_point_left_end)
 		
 		# Draw second triangle
-		st.set_uv(uv_value_right_1)
-		st.add_vertex(trail_point_right_1)
-		st.set_uv(uv_value_left_2)
-		st.add_vertex(trail_point_left_2)
-		st.set_uv(uv_value_right_2)
-		st.add_vertex(trail_point_right_2)
+		st.set_uv(uv_value_right_end)
+		st.add_vertex(trail_point_right_start)
+		st.set_uv(uv_value_left_end)
+		st.add_vertex(trail_point_left_start)
+		st.set_uv(uv_value_right_start)
+		st.add_vertex(trail_point_right_end)
 	
 	st.generate_normals()
 	_trail_mesh_instance.mesh = st.commit()

--- a/Player/GrenadeLauncher.gd
+++ b/Player/GrenadeLauncher.gd
@@ -98,7 +98,6 @@ func _draw_throw_path() -> void:
 	var end_time := _time_to_land + 0.5
 	var point_previous = Vector3.ZERO
 	var time_current := 0.0
-	var uv_progress_factor := TIME_STEP / end_time
 	# We'll create 2 triangles on each iteration, representing the quad of one
 	# section of the path
 	while time_current < end_time:
@@ -113,14 +112,14 @@ func _draw_throw_path() -> void:
 		
 		# UV position goes from 0 to 1, so we normalize the current iteration
 		# to get the progress in the UV texture
-		var uv_progress_end = time_current * uv_progress_factor
-		var uv_progress_start = uv_progress_end - uv_progress_factor
+		var uv_progress_end = time_current/end_time
+		var uv_progress_start = uv_progress_end - (TIME_STEP/end_time)
 		
 		# Left side on the UV texture is at the top of the texture
 		# (Vector2(0,1), or Vector2.DOWN). Right side on the UV texture is at 
 		# the bottom.
-		var uv_value_right_start = (Vector2.RIGHT * uv_progress_end)
-		var uv_value_right_end = (Vector2.RIGHT * uv_progress_start)
+		var uv_value_right_start = (Vector2.RIGHT * uv_progress_start)
+		var uv_value_right_end = (Vector2.RIGHT * uv_progress_end)
 		var uv_value_left_start = Vector2.DOWN + uv_value_right_start
 		var uv_value_left_end = Vector2.DOWN + uv_value_right_end
 		
@@ -130,19 +129,19 @@ func _draw_throw_path() -> void:
 		# clockwise orientation to determine the face normal)
 
 		# Draw first triangle
-		st.set_uv(uv_value_right_start)
+		st.set_uv(uv_value_right_end)
 		st.add_vertex(trail_point_right_end)
-		st.set_uv(uv_value_left_end)
-		st.add_vertex(trail_point_left_start)
 		st.set_uv(uv_value_left_start)
+		st.add_vertex(trail_point_left_start)
+		st.set_uv(uv_value_left_end)
 		st.add_vertex(trail_point_left_end)
 		
 		# Draw second triangle
-		st.set_uv(uv_value_right_end)
-		st.add_vertex(trail_point_right_start)
-		st.set_uv(uv_value_left_end)
-		st.add_vertex(trail_point_left_start)
 		st.set_uv(uv_value_right_start)
+		st.add_vertex(trail_point_right_start)
+		st.set_uv(uv_value_left_start)
+		st.add_vertex(trail_point_left_start)
+		st.set_uv(uv_value_right_end)
 		st.add_vertex(trail_point_right_end)
 	
 	st.generate_normals()

--- a/Player/GrenadeLauncher.tscn
+++ b/Player/GrenadeLauncher.tscn
@@ -1,21 +1,13 @@
-[gd_scene load_steps=8 format=3 uid="uid://b2ew46dlu7u7x"]
+[gd_scene load_steps=6 format=3 uid="uid://b2ew46dlu7u7x"]
 
 [ext_resource type="Script" path="res://Player/GrenadeLauncher.gd" id="1_n50mh"]
 [ext_resource type="Material" uid="uid://dus6jtbfyqwj8" path="res://Player/GrenadeVisuals/aim_material.tres" id="2_qr0pg"]
 [ext_resource type="Material" uid="uid://b6h7p7jogt6ep" path="res://Player/GrenadeVisuals/trajectory_material.tres" id="3_s7dm5"]
-[ext_resource type="Shader" path="res://shared/shaders/wireframe.gdshader" id="4_hsg2p"]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_we0uy"]
 
 [sub_resource type="SphereShape3D" id="SphereShape3D_22ctb"]
 radius = 0.25
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_wylir"]
-render_priority = 0
-shader = ExtResource("4_hsg2p")
-shader_parameter/flat_shading = true
-shader_parameter/wire_smoothness = null
-shader_parameter/wire_width = 2.0
 
 [node name="GrenadeLauncher" type="Node3D"]
 script = ExtResource("1_n50mh")
@@ -52,4 +44,3 @@ debug_shape_custom_color = Color(0.839216, 0.619608, 0.207843, 1)
 [node name="TrailMeshInstance" type="MeshInstance3D" parent="LaunchPoint"]
 unique_name_in_owner = true
 material_override = ExtResource("3_s7dm5")
-material_overlay = SubResource("ShaderMaterial_wylir")

--- a/Player/GrenadeLauncher.tscn
+++ b/Player/GrenadeLauncher.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://bndbhw3bvvijb"]
+[gd_scene load_steps=6 format=3 uid="uid://bndbhw3bvvijb"]
 
 [ext_resource type="Script" path="res://Player/GrenadeLauncher.gd" id="1_n50mh"]
 [ext_resource type="Material" uid="uid://dus6jtbfyqwj8" path="res://Player/GrenadeVisuals/aim_material.tres" id="2_qr0pg"]
@@ -8,14 +8,6 @@
 
 [sub_resource type="SphereShape3D" id="SphereShape3D_22ctb"]
 radius = 0.25
-
-[sub_resource type="Curve3D" id="Curve3D_srweg"]
-_data = {
-"points": PackedVector3Array(0, -1.40668, -0.385703, 0, 1.40668, 0.385703, 0, 0.00851202, 0.00594258, 0, 1.44436, -0.627982, 0, -1.44436, 0.627982, 0, 0, 3),
-"tilts": PackedFloat32Array(0, 0)
-}
-point_count = 2
-up_vector_enabled = false
 
 [node name="GrenadeLauncher" type="Node3D"]
 script = ExtResource("1_n50mh")
@@ -49,21 +41,6 @@ shape = SubResource("SphereShape3D_22ctb")
 max_results = 1
 debug_shape_custom_color = Color(0.839216, 0.619608, 0.207843, 1)
 
-[node name="Path3D" type="Path3D" parent="LaunchPoint"]
+[node name="TrailMeshInstance" type="MeshInstance3D" parent="LaunchPoint"]
 unique_name_in_owner = true
-curve = SubResource("Curve3D_srweg")
-
-[node name="CSGPolygon3D" type="CSGPolygon3D" parent="LaunchPoint/Path3D"]
-polygon = PackedVector2Array(0, 0, 0, 0.05, 0.2, 0.05, 0.2, 0)
-mode = 2
-path_node = NodePath("..")
-path_interval_type = 1
-path_interval = 0.2
-path_simplify_angle = 1.0
-path_rotation = 2
-path_local = true
-path_continuous_u = true
-path_u_distance = 50.0
-path_joined = false
-smooth_faces = true
-material = ExtResource("3_s7dm5")
+material_override = ExtResource("3_s7dm5")

--- a/Player/GrenadeLauncher.tscn
+++ b/Player/GrenadeLauncher.tscn
@@ -1,13 +1,21 @@
-[gd_scene load_steps=6 format=3 uid="uid://bndbhw3bvvijb"]
+[gd_scene load_steps=8 format=3 uid="uid://b2ew46dlu7u7x"]
 
 [ext_resource type="Script" path="res://Player/GrenadeLauncher.gd" id="1_n50mh"]
 [ext_resource type="Material" uid="uid://dus6jtbfyqwj8" path="res://Player/GrenadeVisuals/aim_material.tres" id="2_qr0pg"]
 [ext_resource type="Material" uid="uid://b6h7p7jogt6ep" path="res://Player/GrenadeVisuals/trajectory_material.tres" id="3_s7dm5"]
+[ext_resource type="Shader" path="res://shared/shaders/wireframe.gdshader" id="4_hsg2p"]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_we0uy"]
 
 [sub_resource type="SphereShape3D" id="SphereShape3D_22ctb"]
 radius = 0.25
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_wylir"]
+render_priority = 0
+shader = ExtResource("4_hsg2p")
+shader_parameter/flat_shading = true
+shader_parameter/wire_smoothness = null
+shader_parameter/wire_width = 2.0
 
 [node name="GrenadeLauncher" type="Node3D"]
 script = ExtResource("1_n50mh")
@@ -44,3 +52,4 @@ debug_shape_custom_color = Color(0.839216, 0.619608, 0.207843, 1)
 [node name="TrailMeshInstance" type="MeshInstance3D" parent="LaunchPoint"]
 unique_name_in_owner = true
 material_override = ExtResource("3_s7dm5")
+material_overlay = SubResource("ShaderMaterial_wylir")

--- a/Player/Player.tscn
+++ b/Player/Player.tscn
@@ -260,7 +260,7 @@ render_target_update_mode = 4
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.812403)
 
 [node name="godot_coin" parent="PlayerUI/CoinsContainer/SubViewportContainer/SubViewport/Coin" index="0"]
-transform = Transform3D(-0.993383, 0, 0.114842, 0, 1, 0, -0.114842, 0, -0.993383, 0, 0, 0)
+transform = Transform3D(0.972851, 0, -0.231431, 0, 1, 0, 0.231431, 0, 0.972851, 0, 0, 0)
 y_amplitude = 0.0
 
 [node name="Camera3D" type="Camera3D" parent="PlayerUI/CoinsContainer/SubViewportContainer/SubViewport"]

--- a/project.godot
+++ b/project.godot
@@ -58,8 +58,8 @@ CameraMode="*res://CameraMode/CameraMode.tscn"
 
 window/size/viewport_width=1920
 window/size/viewport_height=1080
-window/size/mode=3
 window/stretch/mode="viewport"
+window/stretch/aspect="keep_height"
 
 [input]
 

--- a/shared/shaders/wireframe.gdshader
+++ b/shared/shaders/wireframe.gdshader
@@ -1,0 +1,31 @@
+shader_type spatial;
+
+uniform float wire_width : hint_range(0.0, 40.0) = 5.0;
+uniform float wire_smoothness : hint_range(0.0, 0.1) = 0.01;
+uniform bool flat_shading = true;
+
+varying vec3 barys;
+
+void vertex() {
+    int index = VERTEX_ID % 3;
+    switch (index) {
+        case 0:
+            barys = vec3(1.0, 0.0, 0.0);
+            break;
+        case 1:
+            barys = vec3(0.0, 1.0, 0.0);
+            break;
+        case 2:
+            barys = vec3(0.0, 0.0, 1.0);
+            break;
+    }
+}
+
+void fragment() {
+    if (flat_shading)
+        NORMAL = normalize(cross(dFdy(VERTEX), dFdx(VERTEX)));
+    vec3 deltas = fwidth(barys);
+    vec3 barys_s = smoothstep(deltas * wire_width - wire_smoothness, deltas * wire_width + wire_smoothness, barys);
+    float min_bary = min(barys_s.x, min(barys_s.y, barys_s.z));
+    ALBEDO = vec3(min_bary);
+}


### PR DESCRIPTION
Using CSGMesh as trail was a quick-win, but it had some shortcomings:
- CSGMesh API isn't stable.
- CSGMesh shouldn't be used as procedural meshes because it is heavy on processing (wasn't affecting the Demo performance but wasn't a good learning example)
- Curve3D API isn't stable too, and sometimes the "up" direction of the curve would break the material UV.

Although SurfaceTool code is much more difficult to read, the code itself is much more stable and performatic, and shows a good usecase to create a procedural mesh.