### PR TITLE
Play the Beetle secondary animation shake

### DIFF
--- a/Enemies/Beetle.gd
+++ b/Enemies/Beetle.gd
@@ -54,8 +54,6 @@ func _physics_process(delta: float) -> void:
 					force *= 10.0
 					collider.damage(impact_point, force)
 					_beetle_skin.attack()
-	else:
-		_beetle_skin.idle()
 
 
 func damage(impact_point: Vector3, force: Vector3) -> void:
@@ -104,3 +102,4 @@ func _on_body_exited(body: Node3D) -> void:
 	if body is Player:
 		_target = null
 		_reaction_animation_player.play("lost_player")
+		_beetle_skin.idle()

--- a/Enemies/beetle_bot/beetlebot_skin.gd
+++ b/Enemies/beetle_bot/beetlebot_skin.gd
@@ -12,16 +12,18 @@ func _ready():
 		anim.loop_mode = Animation.LOOP_LINEAR
 
 func _on_secondary_action_timer_timeout():
-	if _main_state_machine.get_current_node() != "Idle": return
-	_main_state_machine.travel("Shake")
+	if _main_state_machine.get_current_node() == "Idle":
+		shake()
 	_secondary_action_timer.start(randf_range(3.0, 8.0))
 
 func idle():
 	_main_state_machine.travel("Idle")
-	_secondary_action_timer.start()
 	
 func walk():
 	_main_state_machine.travel("Walk")
+	
+func shake():
+	_main_state_machine.travel("Shake")
 	
 func attack():
 	_main_state_machine.travel("Attack")


### PR DESCRIPTION
The secondary idle animation shake was not playing. Though there were code that seams to have intended the animation to play at random intervals.

Ensure that the timer running and when Idle starting the shake animation by traveling the state machine to the Shake state. Removed the continuous call to Idle that cased immediate travel out of Shake again and instead called idle when the Beetle loses track of the player.