### PR TITLE
Fix input setup function when copying character to different project

### DIFF
--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -274,4 +274,6 @@ func _register_input_actions() -> void:
 		if InputMap.has_action(action):
 			continue
 		InputMap.add_action(action)
-		InputMap.action_add_event(action, INPUT_ACTIONS[action])
+		var input_key = InputEventKey.new()
+		input_key.keycode = INPUT_ACTIONS[action]
+		InputMap.action_add_event(action, input_key)


### PR DESCRIPTION
Fixed the function that is used to register the required input actions when the character has been copied to a different project. The previous code sent `INPUT_ACTIONS[action]` as the second argument to [`action_add_events()` ](https://docs.godotengine.org/en/stable/classes/class_inputmap.html#class-inputmap-method-action-add-event), which was read as an `int`. The new code instead creates a new local `InputEvent` with the associated Key `enum` instead.