### PR TITLE
Fix gamepad bindings

### DIFF
--- a/DemoPage/DemoPage.gd
+++ b/DemoPage/DemoPage.gd
@@ -23,7 +23,10 @@ func _ready() -> void:
 	keyboard_button.pressed.connect(change_instruction.bind(INSTRUCTION_TYPES.KEYBOARD))
 	joypad_button.pressed.connect(change_instruction.bind(INSTRUCTION_TYPES.JOYPAD))
 	
-	change_instruction(INSTRUCTION_TYPES.KEYBOARD)
+	if Input.get_connected_joypads().size() > 0:
+		change_instruction(INSTRUCTION_TYPES.JOYPAD)
+	else:
+		change_instruction(INSTRUCTION_TYPES.KEYBOARD)
 
 
 func _input(event: InputEvent) -> void:

--- a/DemoPage/DemoPage.tscn
+++ b/DemoPage/DemoPage.tscn
@@ -432,7 +432,7 @@ stretch_mode = 5
 [node name="Label" type="Label" parent="CanvasLayer/DemoPageRoot/Content/Content/GameDescription/MarginContainer/ContentContainer/ControlsDescription/MarginContainer/VBoxContainer/GridContainerJoypad/HBoxContainer7"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = ": Pause"
+text = ": Pause / Resume"
 label_settings = SubResource("LabelSettings_f30p8")
 
 [node name="ButtonContainer" type="HBoxContainer" parent="CanvasLayer/DemoPageRoot/Content/Content/GameDescription/MarginContainer/ContentContainer/ControlsDescription/MarginContainer/VBoxContainer"]

--- a/project.godot
+++ b/project.godot
@@ -62,22 +62,22 @@ jump={
 }
 camera_left={
 "deadzone": 0.5,
-"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":3,"axis_value":-1.0,"script":null)
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":2,"axis_value":-1.0,"script":null)
 ]
 }
 camera_right={
 "deadzone": 0.5,
-"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":3,"axis_value":1.0,"script":null)
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":2,"axis_value":1.0,"script":null)
 ]
 }
 camera_up={
 "deadzone": 0.5,
-"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":4,"axis_value":-1.0,"script":null)
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":3,"axis_value":-1.0,"script":null)
 ]
 }
 camera_down={
 "deadzone": 0.5,
-"events": [null, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":4,"axis_value":1.0,"script":null)
+"events": [null, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":3,"axis_value":1.0,"script":null)
 ]
 }
 attack={
@@ -89,7 +89,7 @@ attack={
 aim={
 "deadzone": 0.5,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"pressed":false,"double_click":false,"script":null)
-, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":2,"axis_value":1.0,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":4,"axis_value":1.0,"script":null)
 ]
 }
 swap_weapons={
@@ -101,6 +101,7 @@ swap_weapons={
 pause={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 


### PR DESCRIPTION
The camera controls were connected to the wrong axes, and the pause action had no mapping so it was impossible to start the game.

Also made it autodetect when a controller is connected, so that it shows the controller mappings by default (otherwise there's no way to toggle the button currently).

And changed the "Pause" label to "Pause / Resume" to make it clearer that it's the button that will start the game.

New bindings tested with an Xbox Series controller on Windows 10 and Linux.