### PR TITLE
fix: Remove unused mtl reference in `grass_1_geo.obj`

### DIFF
--- a/Environment/grass/grass_1_geo.obj
+++ b/Environment/grass/grass_1_geo.obj
@@ -1,6 +1,5 @@
 # Blender 3.3.1
 # www.blender.org
-mtllib grass_1_geo.mtl
 o Plane.032
 v 0.643635 0.379150 -0.155953
 v 0.553739 0.379150 -0.029316


### PR DESCRIPTION
Solves a (harmless) error about not being able to load `grass_1_geo.mtl`.

---

Unrelated, but after #30 I think the demo is in a pretty good state for a new tagged release compatible with 4.1.x. Could be made after merging this commit which solves a minor error on import.